### PR TITLE
Simplify characters iteration

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ async function subsetFont(
 
   // Add unicodes indices
   const inputUnicodes = exports.hb_subset_input_unicode_set(input);
-  for (const c of [...text]) {
+  for (const c of text) {
     exports.hb_set_add(inputUnicodes, c.codePointAt(0));
   }
 


### PR DESCRIPTION
Just to illustrate the issue better,

let text = '👌';
for (let i = 0; i < text.length; i += 1) { console.log(text[i]); } // FAIL: prints two incorrect characters
[...text].forEach(c => console.log(c)) // PASS: prints one character
for (const c of [...text]) { console.log(c); } // PASS
for (const c of text) { console.log(c); } // PASS

Also curious to know why https://github.com/papandreou/subset-font/commit/84ac1955987f5197b0f037d6cf0dde1622d73397 was needed yet this won't revert that and just simplifies it.