### PR TITLE
destroy hb_face correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ async function subsetFont(
   if (subsetByteLength === 0) {
     exports.hb_blob_destroy(result);
     exports.hb_face_destroy(subset);
+    exports.hb_face_destroy(face);
     exports.free(fontBuffer);
     throw new Error(
       'Failed to create subset font, maybe the input file is corrupted?'
@@ -83,6 +84,7 @@ async function subsetFont(
   // Clean up
   exports.hb_blob_destroy(result);
   exports.hb_face_destroy(subset);
+  exports.hb_face_destroy(face);
   exports.free(fontBuffer);
 
   return await fontverter.convert(subsetFont, targetFormat, 'truetype');


### PR DESCRIPTION
1. the font file you use is too small, and I think it's broken. I download the file from #8 , and update it.
2. `face` should be destroyed. You can prove it by log the `input` value  https://github.com/papandreou/subset-font/blob/150b9ddd9cf0dcbb0393ddcb8b1f25ddd6f04cb8/index.js#L45 . This value should not change when input args are the same. And when it get bigger and bigger, the program would fatal. Further more, all alloced ptr should be consistent when  input args are the same.

see also https://github.com/harfbuzz/harfbuzzjs/blob/c141d5872698d6f0d95c2853e0ee4540e688dab1/subset/test.cc#L47

3. `exports.memory.grow(2000)` seems too big. I doubt whether there is such a big font file.