### PR TITLE
Handle strings with UTF-16 surrogate pairs

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,13 @@ async function subsetFont(
 
   // Add unicodes indices
   const inputUnicodes = exports.hb_subset_input_unicode_set(input);
-  for (const c of text) {
-    exports.hb_set_add(inputUnicodes, c.codePointAt(0));
+  for (let i = 0; i < text.length; i++) {
+    let codepoint = text.codePointAt(i);
+    exports.hb_set_add(inputUnicodes, codepoint);
+    if (codepoint > 0xffff) {
+      // We're dealing with a UTF-16 surrogate pair
+      i++;
+    }
   }
 
   let subset;

--- a/index.js
+++ b/index.js
@@ -71,8 +71,7 @@ async function subsetFont(
   const inputUnicodes = exports.hb_subset_input_unicode_set(input);
   for (let i = 0; i < text.length; i++) {
     let codepoint = text.codePointAt(i);
-    // Harbuzz seems to expect only the lowest 16 bits of the unicode codepoint
-    exports.hb_set_add(inputUnicodes, codepoint % 0x10000);
+    exports.hb_set_add(inputUnicodes, codepoint);
     if (codepoint > 0xffff) {
       // We're dealing with a UTF-16 surrogate pair
       i++;

--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ async function subsetFont(
   const inputUnicodes = exports.hb_subset_input_unicode_set(input);
   for (let i = 0; i < text.length; i++) {
     let codepoint = text.codePointAt(i);
-    exports.hb_set_add(inputUnicodes, codepoint);
+    // Harbuzz seems to expect only the lowest 16 bits of the unicode codepoint
+    exports.hb_set_add(inputUnicodes, codepoint % 0x10000);
     if (codepoint > 0xffff) {
       // We're dealing with a UTF-16 surrogate pair
       i++;


### PR DESCRIPTION
Fixes the code that iterates through the subset text for codepoints to handle UTF-16 surrogate pairs.

Fixes #15 