### PR TITLE
Prepare for the upcoming release of harfbuzzjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const loadAndInitializeHarfbuzz = _.once(async () => {
   const {
     instance: { exports },
   } = await WebAssembly.instantiate(
-    await readFile(require.resolve('harfbuzzjs/subset/hb-subset.wasm'))
+    await readFile(require.resolve('harfbuzzjs/hb-subset.wasm'))
   );
   exports.memory.grow(2000); // each page is 64kb in size
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const loadAndInitializeHarfbuzz = _.once(async () => {
   } = await WebAssembly.instantiate(
     await readFile(require.resolve('harfbuzzjs/hb-subset.wasm'))
   );
-  exports.memory.grow(2000); // each page is 64kb in size
 
   const heapu8 = new Uint8Array(exports.memory.buffer);
   return [exports, heapu8];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "fontverter": "^2.0.0",
-    "harfbuzzjs": "^0.2.1",
+    "harfbuzzjs": "^0.3.0",
     "lodash": "^4.17.21",
     "p-limit": "^3.1.0"
   },


### PR DESCRIPTION
There's a new release of harfbuzzjs in the works, which uses Emscripten and updates harfbuzz to 4.x. It has not been released yet, but I've tested this against [the `main` branch](https://github.com/harfbuzz/harfbuzzjs/tree/main) as of https://github.com/harfbuzz/harfbuzzjs/commit/b761c401c0bdfb9ff2a9490db8c9cbb3ff2c4fc7 with both the `subset-font` and `subfont` test suites.

Related discussion: https://github.com/harfbuzz/harfbuzzjs/issues/39#issuecomment-1190539166